### PR TITLE
fix missing slashes when a windows folder starts with an under score

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ class CreateFolders(Application):
                 self.log_info("*Creating folders would generate %d items on disk:*" % len(paths))
                 self.log_info("")
                 for p in paths:
-                    self.log_info(p)
+                    self.log_info(p.replace(r'\_', r'\\_'))
                 self.log_info("")
                 self.log_info("Note that some of these folders may exist on disk already.")
                 


### PR DESCRIPTION
the backslash escapes the underscore so paths such as `c:\asset\_psd\` renders as `c:\asset_psd\` which can be confusing when setting up templates.